### PR TITLE
Fix header rebuild for TTL forwarding

### DIFF
--- a/app/src/main/java/com/chat/app/Main.java
+++ b/app/src/main/java/com/chat/app/Main.java
@@ -11,6 +11,8 @@ public class Main {
         SwingUtilities.invokeLater(() -> {
             NetworkManager netMgr = new NetworkManager();
             GatewayManager  gwMgr  = new GatewayManager();
+            netMgr.setGatewayManager(gwMgr);
+            gwMgr.setNetworkManager(netMgr);
             MainFrame       ui     = new MainFrame(netMgr, gwMgr);
             ui.setVisible(true);
         });

--- a/network/src/main/java/com/chat/network/PacketListener.java
+++ b/network/src/main/java/com/chat/network/PacketListener.java
@@ -36,7 +36,7 @@ class PacketListener implements Runnable {
             while (running) {
                 DatagramPacket pkt = new DatagramPacket(buf, buf.length);
                 sock.receive(pkt);
-                mgr.handleIncoming(pkt.getData(), pkt.getLength());
+                mgr.processIncoming(pkt.getData(), pkt.getLength());
             }
 
         } catch (SocketException se) {

--- a/ui/src/main/java/com/chat/ui/MainFrame.java
+++ b/ui/src/main/java/com/chat/ui/MainFrame.java
@@ -162,6 +162,7 @@ public class MainFrame extends JFrame {
         try {
             netMgr.setNickname(nickname);
             netMgr.start();
+            gwMgr.start();
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(this,
                     "Network start failed:\n" + ex.getMessage(),
@@ -197,6 +198,7 @@ public class MainFrame extends JFrame {
         } catch (Exception ignored) { }
 
         netMgr.stop();
+        gwMgr.stop();
 
         miConnect.setEnabled(true);
         miDisconnect.setEnabled(false);


### PR DESCRIPTION
## Summary
- update TTL decrement handling in `NetworkManager`
- propagate frames across gateways and local network with updated headers
- deduplicate forwarded frames in `GatewayManager`
- link `NetworkManager` and `GatewayManager` together
- start/stop gateways from the UI

## Testing
- `javac @sources.txt` *(fails: package org.slf4j does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68550ea3a158832398c6018aabc97b09