### PR TITLE
Start and stop gateway

### DIFF
--- a/ui/src/main/java/com/chat/ui/MainFrame.java
+++ b/ui/src/main/java/com/chat/ui/MainFrame.java
@@ -162,9 +162,11 @@ public class MainFrame extends JFrame {
         try {
             netMgr.setNickname(nickname);
             netMgr.start();
+            gwMgr.start();
+            statusBar.setGateway(true);
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(this,
-                    "Network start failed:\n" + ex.getMessage(),
+                    "Network/Gateway start failed:\n" + ex.getMessage(),
                     "Error", JOptionPane.ERROR_MESSAGE);
             return;
         }
@@ -197,6 +199,8 @@ public class MainFrame extends JFrame {
         } catch (Exception ignored) { }
 
         netMgr.stop();
+        gwMgr.stop();
+        statusBar.setGateway(false);
 
         miConnect.setEnabled(true);
         miDisconnect.setEnabled(false);

--- a/ui/src/main/java/com/chat/ui/StatusBar.java
+++ b/ui/src/main/java/com/chat/ui/StatusBar.java
@@ -5,14 +5,16 @@ import javax.swing.*;
 import java.awt.*;
 
 public class StatusBar extends JPanel {
-    private final JLabel mode = new JLabel("Mode: CLIENT");
-    private final JLabel peers = new JLabel("Peers: 0");
+    private final JLabel mode    = new JLabel("Mode: CLIENT");
+    private final JLabel peers   = new JLabel("Peers: 0");
+    private final JLabel gateway = new JLabel("Gateway: OFF");
 
     public StatusBar() {
         setLayout(new FlowLayout(FlowLayout.LEFT));
-        add(mode); add(peers);
+        add(mode); add(peers); add(gateway);
     }
 
-    public void setMode(String m){ mode.setText("Mode: "+m);}
-    public void setPeerCount(int n){ peers.setText("Peers: "+n);}
+    public void setMode(String m){ mode.setText("Mode: "+m); }
+    public void setPeerCount(int n){ peers.setText("Peers: "+n); }
+    public void setGateway(boolean on){ gateway.setText("Gateway: "+(on?"ON":"OFF")); }
 }


### PR DESCRIPTION
## Summary
- start GatewayManager when connecting
- stop GatewayManager when disconnecting
- display gateway status in status bar

## Testing
- `javac $(find . -name '*.java' | tr '\n' ' ')` *(fails: package org.slf4j does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6855137ebd848323a1512c0f03be57ad